### PR TITLE
Enable AndroidX for Gradle build

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -31,9 +31,14 @@ android {
         compose = true
     }
 
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
 
-
-    kotlinOptions { jvmTarget = "17" }
+    kotlinOptions {
+        jvmTarget = "17"
+    }
 
     packaging {
         resources.excludes += setOf("META-INF/AL2.0", "META-INF/LGPL2.1")

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,4 +1,4 @@
-<manifest package="app.brightnesspulse" xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC"/>

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,3 @@
+# Enable AndroidX and migrate old support libraries
+android.useAndroidX=true
+android.enableJetifier=true


### PR DESCRIPTION
## Summary
- enable AndroidX and Jetifier via gradle.properties
- align Java and Kotlin compile targets to 17 and clean Kotlin options block
- drop deprecated package attribute from AndroidManifest
- document AndroidX settings in gradle.properties

## Testing
- `./gradlew :app:assembleDebug` *(fails: SDK location not found)*
- `sudo apt-get install -y android-sdk` *(fails: ca-certificates-java configuration error)*

------
https://chatgpt.com/codex/tasks/task_e_68ad70d1f2cc83288aad0ed6eb1692dc